### PR TITLE
bugfix：页面中存在多层 modal，关闭最上层 modal，下层 modal 显示样式会受到影响

### DIFF
--- a/addon/components/io-modal.js
+++ b/addon/components/io-modal.js
@@ -1,28 +1,47 @@
 import Ember from 'ember';
 
+var openedModals = 0;
+
 export default Ember.Component.extend({
-	modalNode: null,
 
-	show: false,
+  modalNode: null,
 
-	visibility: Ember.computed('show', function(){
-		return this.get('show') ? 'show' : 'hide';
-	}),
+  show: false,
 
-	_onShowChange: Ember.observer('show', function() {
-		var $node = this.get('modalNode');
-		if ($node) {
-			$node.modal(this.get('visibility'));
-		}
-	}),
+  visibility: Ember.computed('show', function () {
+    return this.get('show') ? 'show' : 'hide';
+  }),
 
-	didInsertElement: function() {
-		var $node = this.$('.modal');
-		this.set('modalNode', $node);
-		$node.modal(this.get('visibility'));
-	},
+  _onShowChange: Ember.observer('show', function () {
+    var $node = this.get('modalNode');
+    if ($node) {
+      $node.modal(this.get('visibility'));
+    }
+  }),
 
-	willDestroyElement: function() {
-		this.get('modalNode').modal('hide');
-	}
+  didInsertElement: function () {
+    var $node = this.$('.modal');
+    this.set('modalNode', $node);
+    $node.modal(this.get('visibility'));
+
+    $node.on('shown.bs.modal', function () {
+      openedModals += 1;
+    });
+
+    $node.on('hidden.bs.modal', function () {
+      openedModals -= 1;
+
+      if (hasOpenedModal()) {
+        Ember.$('body').addClass('modal-open');
+      }
+    });
+  },
+
+  willDestroyElement: function () {
+    this.get('modalNode').modal('hide');
+  }
 });
+
+var hasOpenedModal = function () {
+  return openedModals > 0;
+}


### PR DESCRIPTION
hide bootstrap 的 modal 时，会调用 hideModal ，并执行 that.$body.removeClass('modal-open’)。
