### PR TITLE
Update io-table.js

### DIFF
--- a/addon/components/io-table.js
+++ b/addon/components/io-table.js
@@ -439,7 +439,7 @@ export default Component.extend({
         const indexNumberBase = this.get('indexNumberBase') || 0;
         const showIndexNumber = this.get('showIndexNumber');
         data.forEach((it, index) => {
-            it.__index = index + indexNumberBase;
+            set(it, '__index', index + indexNumberBase);
         });
 
         // global search


### PR DESCRIPTION
__index在模板中使用了，相当于添加了一个observer，直接修改__index的值在特殊情况下会报错。
app/templates/components/models-table/row.hbs

```
  {{#if showIndexNumber}}
    <td>{{record.__index}}</td>
  {{/if}}
```

![image](https://cloud.githubusercontent.com/assets/2957936/14878058/9a8931e4-0d53-11e6-8283-a177f467ba3e.png)
